### PR TITLE
Fix deploy workflow: correct path to city.json

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
           import random
           
           # Load the base city configuration
-          with open('city.json', 'r') as f:
+          with open('docs/city.json', 'r') as f:
               city_config = json.load(f)
           
           # Generate additional city variations for the webapp


### PR DESCRIPTION
## Fix Deploy Workflow Path Issue

**Problem:** The deploy workflow was failing because it was trying to read `city.json` from the root directory, but the file is actually located at `docs/city.json`.

**Error:** 
```
FileNotFoundError: [Errno 2] No such file or directory: 'city.json'
```

**Solution:** 
- Updated the deploy workflow to read from `docs/city.json` instead of `city.json`
- This fixes the GitHub Pages deployment that was failing after merging PR #13

**Files Changed:**
- `.github/workflows/deploy.yml` - Fixed file path in city data generation step

This is a quick fix to resolve the deployment issue on the main branch.